### PR TITLE
[BUG] ESLint can now lint tests files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,15 +11,17 @@
   },
   "env": {
     "node": true,
-    "es6": true,
-    "jest/globals": true
+    "es6": true
   },
   "overrides": [
     {
-      "files": ["*.test.*"],
+      "files": ["__tests__/*"],
       "plugins": ["jest"],
       "env": {
         "jest/globals": true
+      },
+      "parserOptions": {
+        "project": "__tests__/tsconfig.json"
       },
       "extends": ["plugin:jest/recommended"],
       "rules": {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -6,30 +6,34 @@ import * as fs from 'fs'
 import {expect, test} from '@jest/globals'
 
 test('throws invalid number', async () => {
-  const input = parseInt('foo', 10)
-  await expect(Wait(input)).rejects.toThrow('milliseconds not a number')
+  const INPUT:number = parseInt('foo', 10)
+  await expect(Wait(INPUT)).rejects.toThrow('milliseconds not a number')
 })
 
 test('wait 500 ms', async () => {
-  const start = new Date()
+  const START:Date = new Date()
   await Wait(500)
-  const end = new Date()
-  var delta = Math.abs(end.getTime() - start.getTime())
-  expect(delta).toBeGreaterThan(450)
+  const END:Date = new Date()
+  const DELTA:number = Math.abs(END.getTime() - START.getTime())
+  expect(DELTA).toBeGreaterThan(450)
 })
 
 // shows how the runner will run a javascript action with env / stdout protocol
-test('test runs', () => {
-  process.env['INPUT_MILLISECONDS'] = '500'
-  const np = process.execPath
-  const ip = path.join(__dirname, '..', 'lib', 'main.js')
+test('runs', () => {
+  process.env.INPUT_MILLISECONDS = '500'
+  const NP:string = process.execPath
+  const IP:string = path.join(__dirname, '..', 'lib', 'main.js')
 
-  if (!fs.existsSync(ip)) {
+  if (!fs.existsSync(IP)) {
     cp.execSync("npm run build")
   }
   
-  const options: cp.ExecFileSyncOptions = {
+  const OPTIONS: cp.ExecFileSyncOptions = {
     env: process.env
   }
-  console.log(cp.execFileSync(np, [ip], options).toString())
+  
+  const OUTPUT:string = cp.execFileSync(NP, [IP], OPTIONS).toString()
+
+  expect(OUTPUT).toBeDefined()
+
 })

--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",                        /* Redirect output structure to the directory. */
+    "rootDir": "..",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+  },
+  "exclude": ["node_modules", "src"]
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint src/**/*.ts __tests__/**/*.ts",
     "package": "ncc build --source-map --license licenses.txt",
     "test": "jest",
     "all": "npm run build && npm run package",


### PR DESCRIPTION
## 1) Description

Added another tsconfig file that includes the test to make ELINT able to lint the test files. 

## 2) Technical choice

I could have added those files to the original tsconfig file but since it is used to compile the final build the tests would be included in the final build which is not preferable.

## 3) Checks

- [X] My code follows the contributing guidelines
- [X] I have read the code of conduct
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes