### PR TITLE
[FEATURE]Made dependabot update from/to dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: [Refactor]
+    target-branch: development
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
+    labels: [Refactor]
+    target-branch: development


### PR DESCRIPTION
## 1) Description

Making Dependabot use the dev branch instead of the main one. This allows to do more tests and ensure  compatibility before merging to master, while reducing the number of commits to the main branch.

## 3) Checks

- [X] My code follows the contributing guidelines
- [X] I have read the code of conduct
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes