### PR TITLE
[REFACTOR] changed upstream branch

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -21,3 +21,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: Libra-foundation/typescript-action
           pr_title: "[DOWNSTREAM] merge changes from template repository"
+          upstream_branch: "development"


### PR DESCRIPTION
## 1) Description
I changed the upstream branch from the default `main` to `development`. Changes from the template might break a few things and require more tests and small fixes. Therefor, I believe that the default behavior we ship should be to sync into the dev branch.  

## 2) Checks

- [X] My code follows the contributing guidelines
- [X] I have read the code of conduct
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes